### PR TITLE
add new OSINT tool: Hostagram

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -6797,6 +6797,11 @@
       "name": "Smart Questions",
       "type": "url",
       "url": "http://www.catb.org/esr/faqs/smart-questions.html"
+	}
+	{
+	  "name": "Hostagram",
+	  "type": "url",
+	  "url": "https://github.com/banaxou/hostagram"
     }]
   }]
 }


### PR DESCRIPTION
# Hostagram is an instagram OSINT tool 

> **Hostagram extracts and analyzes public information from profiles, with features such as usernames, emails, phone numbers, and other data**